### PR TITLE
Replace force overwrite with cmdline option

### DIFF
--- a/Sitecore.Courier.Runner/App.config
+++ b/Sitecore.Courier.Runner/App.config
@@ -15,7 +15,6 @@
         </fields>
       </filter>
       <filter id="fileCommandFilter" mode="on" type="Sitecore.Courier.FileCommandsFilter, Sitecore.Courier">
-        <forceoverwrites>true</forceoverwrites>
       </filter>
     </commandfilters>
     <dataproviders>

--- a/Sitecore.Courier.Runner/CommandLineOptions.cs
+++ b/Sitecore.Courier.Runner/CommandLineOptions.cs
@@ -3,6 +3,8 @@ using CommandLine.Text;
 
 namespace Sitecore.Courier.Runner
 {
+    using Sitecore.Update;
+
     // Define a class to receive parsed values
     class Options
     {
@@ -17,6 +19,10 @@ namespace Sitecore.Courier.Runner
         [Option('o', "output", Required = true,
           HelpText = "Location of update package")]
         public string Output { get; set; }
+        
+        [Option('c', "collisionBehavior", Required = false, DefaultValue = CollisionBehavior.Undefined,
+          HelpText = "The collision behavior (default, force or skip) for the update package.")]
+        public CollisionBehavior CollisionBehavior { get; set; }
 
         [ParserState]
         public IParserState LastParserState { get; set; }

--- a/Sitecore.Courier.Runner/Program.cs
+++ b/Sitecore.Courier.Runner/Program.cs
@@ -21,8 +21,9 @@
                 Console.WriteLine("Source: {0}", options.Source);
                 Console.WriteLine("Target: {0}", options.Target);
                 Console.WriteLine("Output: {0}", options.Output);
+                Console.WriteLine("Collision behavior: {0}", options.CollisionBehavior);
                 var diff = new DiffInfo(
-                    DiffGenerator.GetDiffCommands(options.Source, options.Target),
+                    DiffGenerator.GetDiffCommands(options.Source, options.Target, options.CollisionBehavior),
                     "Sitecore Courier Package",
                     string.Empty,
                     string.Format("Diff between serialization folders '{0}' and '{1}'.", options.Source, options.Target));

--- a/Sitecore.Courier/DIffGenerator.cs
+++ b/Sitecore.Courier/DIffGenerator.cs
@@ -5,6 +5,8 @@ using Sitecore.Update.Commands;
 namespace Sitecore.Courier
 {
   using System.Collections.Generic;
+
+  using Sitecore.Update;
   using Sitecore.Update.Configuration;
   using Sitecore.Update.Data;
   using Sitecore.Update.Interfaces;
@@ -14,7 +16,7 @@ namespace Sitecore.Courier
   /// </summary>
   public class DiffGenerator
   {
-    public static List<ICommand> GetDiffCommands(string sourcePath, string targetPath)
+    public static List<ICommand> GetDiffCommands(string sourcePath, string targetPath, CollisionBehavior collisionBehavior = CollisionBehavior.Undefined)
     {
       var targetManager = Factory.Instance.GetSourceDataManager();
       var sourceManager = Factory.Instance.GetTargetDataManager();
@@ -47,6 +49,8 @@ namespace Sitecore.Courier
           //if the itempath of a delete command starts with this delete command, it will be moved along to the new node, not deleted, just leave it alone
           commands.RemoveAll(c => c is DeleteItemCommand && ((DeleteItemCommand)c).ItemPath.StartsWith(command.Deleted.ItemPath));
       }
+
+      commands.ForEach(_ => _.CollisionBehavior = collisionBehavior);
 
       engine.ProcessCommands(ref commands);
       return commands;

--- a/Sitecore.Courier/FileCommandsFilter.cs
+++ b/Sitecore.Courier/FileCommandsFilter.cs
@@ -23,11 +23,6 @@ namespace Sitecore.Courier
     }
 
     public List<string> ExcludedFolders { get { return excludedFolders; } set { excludedFolders = value; } }
-    public bool ForceOverwrites
-    {
-        get { return forceoverwrites; }
-        set { forceoverwrites = value; }
-    }
 
     /// <summary>
     /// Filters the command. 
@@ -38,16 +33,7 @@ namespace Sitecore.Courier
     {
       if (command == null)
         return null;
-
-      if (ForceOverwrites)
-      {
-          command.CollisionBehavior = CollisionBehavior.Force;
-      }
-      else
-      {
-          command.CollisionBehavior = CollisionBehavior.Skip;
-      }
-
+        
       if (!(command is AddFolderCommand) && !(command is AddFileCommand))
       {
         return command;
@@ -71,7 +57,6 @@ namespace Sitecore.Courier
     {
         return new FileCommandsFilter()
         {
-            ForceOverwrites = this.ForceOverwrites,
             ExcludedFolders = excludedFolders
         };
     }


### PR DESCRIPTION
At the moment the collision behavior each command gets can be set with the
FileCommandFilter which gets configured in the app.config.
We would like to be able to change the collision behavior just by passing
a command line option.

In this PR I added a command line option `-collisionBehavior` which can be
set to `force` or `skip`. Each command then gets this collisionBehavior
mode.