### PR TITLE
Bugfix for multilist fields when using Rainbow file format

### DIFF
--- a/.vs/config/applicationhost.config
+++ b/.vs/config/applicationhost.config
@@ -163,7 +163,7 @@
             </site>
             <site name="Sitecore.Courier.WebRunner" id="2">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\github\Sitecore-Courier\Sitecore.Courier.WebRunner" />
+                    <virtualDirectory path="/" physicalPath="C:\Projects\Various\OpenSource\thomasddn\Sitecore-Courier\Sitecore.Courier.WebRunner" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:11293:localhost" />

--- a/Sitecore.Courier.Runner/App.config
+++ b/Sitecore.Courier.Runner/App.config
@@ -2,14 +2,15 @@
 <configuration>
   <configSections>
     <section name="sitecorediff" type="Sitecore.Update.Configuration.ConfigReader, Sitecore.Update"/>
-    <!--<section name="rainbow" />-->
+    <section name="rainbow" type="Sitecore.Courier.Rainbow.Configuration.RainbowConfigSection, Sitecore.Courier" />
   </configSections>
-  <!--<rainbow>
-    <serializationFormatter type="Rainbow.Storage.Yaml.YamlSerializationFormatter, Rainbow.Storage.Yaml" singleInstance="true">
+  <rainbow>
+    <serializationFormatter type="Rainbow.Storage.Yaml.YamlSerializationFormatter, Rainbow.Storage.Yaml">
       <fieldFormatter type="Rainbow.Formatting.FieldFormatters.MultilistFormatter, Rainbow" />
       <fieldFormatter type="Rainbow.Formatting.FieldFormatters.XmlFieldFormatter, Rainbow" />
+      <fieldFormatter type="Rainbow.Formatting.FieldFormatters.CheckboxFieldFormatter, Rainbow" />
     </serializationFormatter>
-  </rainbow>-->
+  </rainbow>
   <sitecorediff>
     <commandfilters>
       <filter id="changedFieldsFilter" mode="on" type="Sitecore.Update.Commands.Filters.ChangedFieldsFilter, Sitecore.Update">

--- a/Sitecore.Courier/Rainbow/Configuration/FieldFormatterCollection.cs
+++ b/Sitecore.Courier/Rainbow/Configuration/FieldFormatterCollection.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Configuration;
+
+namespace Sitecore.Courier.Rainbow.Configuration
+{
+    public class FieldFormatterCollection : ConfigurationElementCollection, IEnumerable<FieldFormatterElement>
+    {
+        private readonly List<FieldFormatterElement> elements;
+
+        public FieldFormatterCollection()
+        {
+            this.elements = new List<FieldFormatterElement>();
+        }
+
+        protected override ConfigurationElement CreateNewElement()
+        {
+            var element = new FieldFormatterElement();
+            this.elements.Add(element);
+            return element;
+        }
+
+        protected override object GetElementKey(ConfigurationElement element)
+        {
+            return ((FieldFormatterElement)element).Type;
+        }
+
+        public new IEnumerator<FieldFormatterElement> GetEnumerator()
+        {
+            return this.elements.GetEnumerator();
+        }
+    }
+}

--- a/Sitecore.Courier/Rainbow/Configuration/FieldFormatterElement.cs
+++ b/Sitecore.Courier/Rainbow/Configuration/FieldFormatterElement.cs
@@ -1,0 +1,14 @@
+﻿using System.Configuration;
+
+namespace Sitecore.Courier.Rainbow.Configuration
+{
+    public class FieldFormatterElement : ConfigurationElement
+    {
+        [ConfigurationProperty("type", IsKey = true, IsRequired = true)]
+        public string Type
+        {
+            get { return this["type"] as string; }
+            set { this["type"] = value; }
+        }
+    }
+}

--- a/Sitecore.Courier/Rainbow/Configuration/RainbowConfigFactory.cs
+++ b/Sitecore.Courier/Rainbow/Configuration/RainbowConfigFactory.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Xml;
+using Rainbow.Formatting;
+
+namespace Sitecore.Courier.Rainbow.Configuration
+{
+    public class RainbowConfigFactory
+    {
+        private readonly RainbowConfigSection configSection;
+
+        public RainbowConfigFactory(RainbowConfigSection configSection)
+        {
+            this.configSection = configSection;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ISerializationFormatter"/> based on the rainbow config section.
+        /// </summary>
+        public ISerializationFormatter CreateFormatter()
+        {
+            var formatterType = Type.GetType(this.configSection.SerializationFormatterElement.Type, false, true);
+            var configSectionxml = this.configSection.GetSectionXml();
+
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(configSectionxml);
+
+            XmlNode serializationFormatterNode = null;
+
+            if (xmlDoc.FirstChild != null)
+            {
+                serializationFormatterNode = xmlDoc.FirstChild.FirstChild;
+            }
+
+            return Activator.CreateInstance(formatterType, serializationFormatterNode, null) as ISerializationFormatter;
+        }
+    }
+}

--- a/Sitecore.Courier/Rainbow/Configuration/RainbowConfigSection.cs
+++ b/Sitecore.Courier/Rainbow/Configuration/RainbowConfigSection.cs
@@ -1,0 +1,19 @@
+using System.Configuration;
+
+namespace Sitecore.Courier.Rainbow.Configuration
+{
+    public class RainbowConfigSection : ConfigurationSection
+    {
+        [ConfigurationProperty("serializationFormatter")]
+        public SerializationFormatterElement SerializationFormatterElement
+        {
+            get { return (SerializationFormatterElement)this["serializationFormatter"]; }
+            set { this["serializationFormatter"] = value; }
+        }
+
+        public string GetSectionXml()
+        {
+            return SerializeSection(null, SectionInformation.SectionName, ConfigurationSaveMode.Modified);
+        }
+    }
+}

--- a/Sitecore.Courier/Rainbow/Configuration/SerializationFormatterElement.cs
+++ b/Sitecore.Courier/Rainbow/Configuration/SerializationFormatterElement.cs
@@ -1,0 +1,21 @@
+using System.Configuration;
+
+namespace Sitecore.Courier.Rainbow.Configuration
+{
+    public class SerializationFormatterElement : ConfigurationElement
+    {
+        [ConfigurationProperty("type", IsKey = true, IsRequired = true)]
+        public string Type
+        {
+            get { return this["type"] as string; }
+            set { this["type"] = value; }
+        }
+
+        [ConfigurationProperty("", IsDefaultCollection = true)]
+        [ConfigurationCollection(typeof(FieldFormatterCollection), AddItemName = "fieldFormatter")]
+        public FieldFormatterCollection FieldFormatters
+        {
+            get { return (FieldFormatterCollection)this[""]; }
+        }
+    }
+}

--- a/Sitecore.Courier/Rainbow/RainbowSerializationProvider.cs
+++ b/Sitecore.Courier/Rainbow/RainbowSerializationProvider.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Diagnostics;
+﻿using System.Collections.Generic;
+using System.Configuration;
 using System.IO;
 using Rainbow.Storage;
 using Rainbow.Storage.Yaml;
+using Sitecore.Courier.Rainbow.Configuration;
 using Sitecore.Update;
 using Sitecore.Update.Filters;
 using Sitecore.Update.Interfaces;
@@ -19,10 +18,15 @@ namespace Sitecore.Courier.Rainbow
     {
         public static bool Enabled = false;
         private readonly string _name;
+        private readonly YamlSerializationFormatter _formatter;
 
         public RainbowSerializationProvider(string name) : base(name)
         {
             _name = name;
+
+            var config = (RainbowConfigSection)ConfigurationManager.GetSection("rainbow");
+            var rainbowConfigFactory = new RainbowConfigFactory(config);
+            _formatter = rainbowConfigFactory.CreateFormatter() as YamlSerializationFormatter;
         }
 
         public object Clone()
@@ -37,9 +41,7 @@ namespace Sitecore.Courier.Rainbow
 
         public IDataIterator GetIterator(string rootPath, IList<Filter> filters)
         {
-            //TODO: from config?
-            var formatter = new YamlSerializationFormatter(null, null);
-            return new RainbowIterator(rootPath, formatter);
+            return new RainbowIterator(rootPath, _formatter);
         }
     }
 

--- a/Sitecore.Courier/Sitecore.Courier.csproj
+++ b/Sitecore.Courier/Sitecore.Courier.csproj
@@ -44,12 +44,12 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Rainbow, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Rainbow.Core.1.1.0-beta04\lib\net45\Rainbow.dll</HintPath>
+    <Reference Include="Rainbow, Version=1.3.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rainbow.Core.1.3.1\lib\net45\Rainbow.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Rainbow.Storage.Yaml, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Rainbow.Storage.Yaml.1.1.0-beta04\lib\net45\Rainbow.Storage.Yaml.dll</HintPath>
+    <Reference Include="Rainbow.Storage.Yaml, Version=1.3.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rainbow.Storage.Yaml.1.3.1\lib\net45\Rainbow.Storage.Yaml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Sitecore.Kernel, Version=6.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -68,6 +68,7 @@
       <HintPath>lib\Sitecore.Zip.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -75,6 +76,11 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Rainbow\Configuration\FieldFormatterCollection.cs" />
+    <Compile Include="Rainbow\Configuration\FieldFormatterElement.cs" />
+    <Compile Include="Rainbow\Configuration\RainbowConfigFactory.cs" />
+    <Compile Include="Rainbow\Configuration\RainbowConfigSection.cs" />
+    <Compile Include="Rainbow\Configuration\SerializationFormatterElement.cs" />
     <Compile Include="Rainbow\RainbowDataItem.cs" />
     <Compile Include="Rainbow\RainbowSerializationProvider.cs" />
     <Compile Include="ItemUtils.cs" />

--- a/Sitecore.Courier/packages.config
+++ b/Sitecore.Courier/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Rainbow.Core" version="1.1.0-beta04" targetFramework="net45" />
-  <package id="Rainbow.Storage.Yaml" version="1.1.0-beta04" targetFramework="net45" />
+  <package id="Rainbow.Core" version="1.3.1" targetFramework="net45" />
+  <package id="Rainbow.Storage.Yaml" version="1.3.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Hi,

The current implementations causes errors in the update package when there is a multilist field with multiple values. Instead of having this for the field value:
`{9FD44080-C05E-4A25-B74B-9D63CB62887F}|{20205DAB-747E-4190-AA01-690590729D1E}|{CA0940A9-3557-461D-ABA3-DC457D7F49EE}`

you get this:
```
{9FD44080-C05E-4A25-B74B-9D63CB62887F}&#xD;
{20205DAB-747E-4190-AA01-690590729D1E}&#xD;
{CA0940A9-3557-461D-ABA3-DC457D7F49EE}&#xD;
```

Installing these items in Sitecore lead to invalid values for those fields. I have fixed this by loading the YamlSerializationFormatter and field formatters from the config file. While doing this, I've also updated the Rainbow package to v1.3.1 which includes an extra field formatter (CheckboxFieldFormatter) compared to the previous version.

Kind regards,
Thomas