### PR TITLE
Re-added support for files when using Rainbow

### DIFF
--- a/Sitecore.Courier/Rainbow/RainbowSerializationProvider.cs
+++ b/Sitecore.Courier/Rainbow/RainbowSerializationProvider.cs
@@ -61,7 +61,7 @@ namespace Sitecore.Courier.Rainbow
 
         private void InitStack()
         {
-            _allFiles = Directory.GetFiles(_rootPath, "*" + _formatter.FileExtension, SearchOption.AllDirectories);
+            _allFiles = Directory.GetFiles(_rootPath, "*", SearchOption.AllDirectories);
         }
 
         public IDataItem Next()


### PR DESCRIPTION
Fixes #29 

This modification was forgotten when the removed code was re-introduced in 2017.