### PR TITLE
Changed DiffGenerator quite a bit. For now they are both there, with …

### DIFF
--- a/Sitecore.Courier.Runner/CommandLineOptions.cs
+++ b/Sitecore.Courier.Runner/CommandLineOptions.cs
@@ -35,6 +35,10 @@ namespace Sitecore.Courier.Runner
           HelpText = "Use Rainbow serializer")]
         public bool UseRainbow { get; set; }
 
+        [Option('n', "newdiffgenerator", Required = false,
+          HelpText = "Use new diffgenerator")]
+        public bool UseNewDiffGenerator { get; set; }
+
         [ParserState]
         public IParserState LastParserState { get; set; }
 

--- a/Sitecore.Courier.Runner/Program.cs
+++ b/Sitecore.Courier.Runner/Program.cs
@@ -2,6 +2,8 @@
 using Sitecore.Update.Engine;
 using System;
 using Sitecore.Courier.Rainbow;
+using System.Collections.Generic;
+using Sitecore.Update.Interfaces;
 
 namespace Sitecore.Courier.Runner
 {
@@ -36,6 +38,17 @@ namespace Sitecore.Courier.Runner
                 }
 
                 RainbowSerializationProvider.Enabled = options.UseRainbow;
+                
+                List<ICommand> commands = null;
+                if (options.UseNewDiffGenerator)
+                {
+                    commands = NewDiffGenerator.GetDiffCommands(options.Source, options.Target, options.CollisionBehavior);
+                }
+                else
+                {
+                    commands = DiffGenerator.GetDiffCommands(options.Source, options.Target, options.CollisionBehavior);
+                }
+                
                 var diff = new DiffInfo(
                     DiffGenerator.GetDiffCommands(options.Source, options.Target, options.CollisionBehavior),
                     "Sitecore Courier Package",

--- a/Sitecore.Courier/NewDIffGenerator.cs
+++ b/Sitecore.Courier/NewDIffGenerator.cs
@@ -1,0 +1,134 @@
+﻿using Sitecore.Courier.Iterators;
+using Sitecore.Update;
+using Sitecore.Update.Commands;
+using Sitecore.Update.Configuration;
+using Sitecore.Update.Data;
+using Sitecore.Update.Data.Items;
+using Sitecore.Update.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Sitecore.Courier
+{
+    /// <summary>
+    /// Defines the Diff generator class.
+    /// </summary>
+    public class NewDiffGenerator
+    {
+        /// <returns></returns>
+        public static List<ICommand> GetDiffCommands(string sourcePath, string targetPath, CollisionBehavior collisionBehavior = CollisionBehavior.Undefined)
+        {
+            var sourceManager = Factory.Instance.GetSourceDataManager();
+            var targetManager = Factory.Instance.GetTargetDataManager();
+
+            sourceManager.SerializationPath = sourcePath;
+            targetManager.SerializationPath = targetPath;
+
+            IDataIterator sourceDataIterator = sourceManager.ItemIterator ?? new EmptyIterator();
+            IDataIterator targetDataIterator = targetManager.ItemIterator;
+
+            var source = Map(sourceDataIterator);
+            var target = Map(targetDataIterator);
+
+            var commands = GetCommands(source, target);
+            
+            var engine = new DataEngine();
+            engine.ProcessCommands(ref commands);
+            return commands;
+        }
+
+        /// <summary>
+        /// Goes through source and target and creates add/update/delete commands as needed
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="target"></param>
+        /// <returns></returns>
+        protected static List<ICommand> GetCommands(Dictionary<string, IDataItem> source, Dictionary<string, IDataItem> target)
+        {
+            var commands = new List<ICommand>();
+            //Iterate through all source items and match them in target. If there's a match, update it and remove from target. Else delete
+            foreach (var old in source)
+            {
+                if (target.ContainsKey(old.Key))
+                {
+                    commands.AddRange(old.Value.GenerateUpdateCommand(target[old.Key]));
+                    target.Remove(old.Key);
+                }
+                else
+                {
+                    commands.AddRange(old.Value.GenerateDeleteCommand());
+                }
+            }
+
+            //The ones still left in target will be the ones that did not compare to any item in source, create add commands
+            commands.AddRange(target.Values.SelectMany(t => t.GenerateAddCommand()));
+
+            return commands;
+        }
+
+        /// <summary>
+        /// Maps an iterator into a Dictionary with unique keys for each item.
+        /// </summary>
+        /// <param name="iterator"></param>
+        /// <returns></returns>
+        protected static Dictionary<string, IDataItem> Map(IDataIterator iterator)
+        {
+            var dict = new Dictionary<string, IDataItem>();
+            while (true)
+            {
+                var item = iterator.Next();
+                if (item != null)
+                {
+                    var key = CreateUniqueKey(item);
+                    try
+                    {
+                        dict.Add(key, item);
+                    }
+                    catch (ArgumentException)
+                    {
+                        //This should not happen unless the dataset is corrupted, which would mean it would not give a proper result
+                        throw new Exception($"Two items got the same unique key. This suggests invalid data. Check {GetItemPath(item)} vs {GetItemPath(dict[key])}");
+                    }
+                }
+                else
+                {
+                    return dict;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates a unique key for an item (a file is the path, an item is the database and ID)
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        protected static string CreateUniqueKey(IDataItem item)
+        {
+            if (item is ContentDataItem)
+            {
+                //Unique key is database and item id
+                var content = item as ContentDataItem;
+                return $"content::{content.DatabaseName}::{content.ItemID}";
+            }
+            else if (item is FileSystemDataItem)
+            {
+                //The path should always be unique for files on windows
+                var file = item as FileSystemDataItem;
+                return $"file::{file.RelatedPath}";
+            }
+            //This should not happen, if it does the throw helps us spot it!
+            throw new Exception($"Unhandled DataItem type {GetItemPath(item)}");
+        }
+
+        /// <summary>
+        /// Only used for improved exception messages (even though it should give the same value as file.HashCode above)
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        protected static string GetItemPath(IDataItem item)
+        {
+            return string.Join("\\", new[] { item.RootPath, item.RelatedPath }.Where(s => !string.IsNullOrWhiteSpace(s)));
+        }
+    }
+}

--- a/Sitecore.Courier/Sitecore.Courier.csproj
+++ b/Sitecore.Courier/Sitecore.Courier.csproj
@@ -96,6 +96,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="NewDIffGenerator.cs" />
     <Compile Include="Iterators\EmptyIterator.cs" />
     <Compile Include="NewCourierPackageCommand.cs" />
     <Compile Include="Rainbow\Configuration\FieldFormatterCollection.cs" />


### PR DESCRIPTION
…an option to use -n to use the NewDIffGenerator

Some thoughts behind the changes

Rather than run through all items in the other iterator to check for complex equalities, I created maps with keys given their individual uniqueness. This should give much better runtimes for large sets of data.
The ContentItem equality comparer was based on Sitecore serialization. Unicorn paths are not unique in the same way - and databasename is not a part of unicorn paths (and depending on how the source and target was made, not necesarily part of the Sitecore either). I create the map key by Database and ItemId which will always be unique.
I honestly don't see the need for anything but full path for files. Given the windows file/foldername conventions
Simplified the logic quite a bit (did I oversimplify?). There's no longer any cleanup of unnecesarily created commands.
I added some exceptions which should only happen on corrupted/incorrect data. It could easily move on silently and just choose 1. But I personally believe exceptions with some info is the better way to go.
The test example I supplied in the issue was flawed. It was made by hand and the 2 fields in the source had the same ID. The new code dectected and gave info on this. The old did not.