### PR TITLE
Did not use the correct range of commands for the new switch

### DIFF
--- a/Sitecore.Courier.Runner/Program.cs
+++ b/Sitecore.Courier.Runner/Program.cs
@@ -50,7 +50,7 @@ namespace Sitecore.Courier.Runner
                 }
                 
                 var diff = new DiffInfo(
-                    DiffGenerator.GetDiffCommands(options.Source, options.Target, options.CollisionBehavior),
+                    commands,
                     "Sitecore Courier Package",
                     string.Empty,
                     string.Format("Diff between serialization folders '{0}' and '{1}'.", options.Source, options.Target));


### PR DESCRIPTION
I made a mistake on the switch after testing, I don't use the correct generated. My tests still hold true, as those were before I made the switch.