### PR TITLE
#44 More granular control over generated packages 

### DIFF
--- a/Sitecore.Courier.Runner/CommandLineOptions.cs
+++ b/Sitecore.Courier.Runner/CommandLineOptions.cs
@@ -5,7 +5,7 @@ using Sitecore.Update;
 namespace Sitecore.Courier.Runner
 {
     // Define a class to receive parsed values
-    class Options
+    public class Options
     {
         [Option('s', "source", Required = false,
           HelpText = "Source files")]
@@ -53,6 +53,19 @@ namespace Sitecore.Courier.Runner
 
         [ParserState]
         public IParserState LastParserState { get; set; }
+
+        
+        [Option('a', "addoperations", Required = false,
+            HelpText = "Disable add operations")]
+        public bool DisableAddOperations { get; set; }
+        
+        [Option('d', "deleteoperations", Required = false,
+            HelpText = "Disable delete operations")]
+        public bool DisableDeleteOperations { get; set; }
+        
+        [Option('u', "updateoperations", Required = false,
+            HelpText = "Disable update operations")]
+        public bool DisableUpdateOperations { get; set; }
 
         [HelpOption]
         public string GetUsage()

--- a/Sitecore.Courier.Runner/Program.cs
+++ b/Sitecore.Courier.Runner/Program.cs
@@ -39,6 +39,9 @@ namespace Sitecore.Courier.Runner
                 Console.WriteLine("Ensure Revision: {0}", options.EnsureRevision);
                 Console.WriteLine("Path to project file: {0}", options.ScProjFilePath);
                 Console.WriteLine("DacPac Output: {0}", options.DacPac);
+                Console.WriteLine("Disabled Add Operations: {0}", options.DisableAddOperations);
+                Console.WriteLine("Disabled Delete Operations: {0}", options.DisableDeleteOperations);
+                Console.WriteLine("Disabled Update Operations: {0}", options.DisableUpdateOperations);
 
                 string version = Guid.NewGuid().ToString();
                 SanitizeOptions(options);
@@ -55,6 +58,10 @@ namespace Sitecore.Courier.Runner
                 RainbowSerializationProvider.IncludeFiles = options.IncludeFiles;
                 RainbowSerializationProvider.EnsureRevision = options.EnsureRevision;
 
+                DiffGenerator.AllowedOperations &= options.DisableAddOperations ? ~AllowedOperations.Create : DiffGenerator.AllowedOperations;
+                DiffGenerator.AllowedOperations &= options.DisableDeleteOperations ? ~AllowedOperations.Delete : DiffGenerator.AllowedOperations;
+                DiffGenerator.AllowedOperations &= options.DisableUpdateOperations ? ~AllowedOperations.Update : DiffGenerator.AllowedOperations;
+                
                 var commands = DiffGenerator.GetDiffCommands(options.Source, options.Target, options.IncludeSecurity, version, options.CollisionBehavior);
 
                 var diff = new DiffInfo(

--- a/Sitecore.Courier.Runnier.ExclusionsTests/ConfigurationTests.cs
+++ b/Sitecore.Courier.Runnier.ExclusionsTests/ConfigurationTests.cs
@@ -114,5 +114,81 @@ namespace Sitecore.Courier.Runner.ExclusionsTests
             var exclusions = ExclusionHandler.GetExcludedItems(xmlPath, configuration);
             Assert.False(exclusions.Any());
         }
+        
+        [Test]
+        public void DiffGeneratorOperationsDisabledByOptions()
+        {
+            var options = new Runner.Options
+            {
+                DisableAddOperations = true,
+                DisableDeleteOperations = true,
+                DisableUpdateOperations = true
+            };
+            
+            SetDiffGeneratorOptions(options);
+
+            Assert.IsFalse(DiffGenerator.AllowedOperations.HasFlag(AllowedOperations.Create));
+            Assert.IsFalse(DiffGenerator.AllowedOperations.HasFlag(AllowedOperations.Update));
+            Assert.IsFalse(DiffGenerator.AllowedOperations.HasFlag(AllowedOperations.Delete));
+        }
+
+        [Test]
+        public void DiffGeneratorOperationsEnableAddByOptions()
+        {
+            var options = new Runner.Options
+            {
+                DisableAddOperations = false,
+                DisableDeleteOperations = true,
+                DisableUpdateOperations = true
+            };
+            
+            SetDiffGeneratorOptions(options);
+            
+            Assert.IsTrue(DiffGenerator.AllowedOperations.HasFlag(AllowedOperations.Create));
+            Assert.IsFalse(DiffGenerator.AllowedOperations.HasFlag(AllowedOperations.Update));
+            Assert.IsFalse(DiffGenerator.AllowedOperations.HasFlag(AllowedOperations.Delete));
+        }
+        
+        [Test]
+        public void DiffGeneratorOperationsEnableAddAndDeleteByOptions()
+        {
+            var options = new Runner.Options
+            {
+                DisableAddOperations = false,
+                DisableDeleteOperations = false,
+                DisableUpdateOperations = true
+            };
+            
+            SetDiffGeneratorOptions(options);
+            
+            Assert.IsTrue(DiffGenerator.AllowedOperations.HasFlag(AllowedOperations.Create));
+            Assert.IsTrue(DiffGenerator.AllowedOperations.HasFlag(AllowedOperations.Delete));
+            Assert.IsFalse(DiffGenerator.AllowedOperations.HasFlag(AllowedOperations.Update));
+        }
+        
+        [Test]
+        public void DiffGeneratorOperationsEnableAllByOptions()
+        {
+            var options = new Runner.Options
+            {
+                DisableAddOperations = false,
+                DisableDeleteOperations = false,
+                DisableUpdateOperations = false
+            };
+            
+            SetDiffGeneratorOptions(options);
+            
+            Assert.IsTrue(DiffGenerator.AllowedOperations.HasFlag(AllowedOperations.Create));
+            Assert.IsTrue(DiffGenerator.AllowedOperations.HasFlag(AllowedOperations.Update));
+            Assert.IsTrue(DiffGenerator.AllowedOperations.HasFlag(AllowedOperations.Delete));
+        }
+        
+        private static void SetDiffGeneratorOptions(Runner.Options options)
+        {
+            DiffGenerator.AllowedOperations = AllowedOperations.Create | AllowedOperations.Delete | AllowedOperations.Update;
+            DiffGenerator.AllowedOperations &= options.DisableAddOperations ? ~AllowedOperations.Create : DiffGenerator.AllowedOperations;
+            DiffGenerator.AllowedOperations &= options.DisableDeleteOperations ? ~AllowedOperations.Delete : DiffGenerator.AllowedOperations;
+            DiffGenerator.AllowedOperations &= options.DisableUpdateOperations ? ~AllowedOperations.Update : DiffGenerator.AllowedOperations;
+        }
     }
 }

--- a/Sitecore.Courier.Runnier.ExclusionsTests/DiffGeneratorTests.cs
+++ b/Sitecore.Courier.Runnier.ExclusionsTests/DiffGeneratorTests.cs
@@ -33,6 +33,30 @@ namespace Sitecore.Courier.Runner.ExclusionsTests
             Assert.AreEqual(1, commands.Count);
             Assert.AreEqual(1, commands.Count(x => x is DeleteItemCommand));
         }
+        
+        [Test]
+        public void DeleteItemsTest_GivenDisabledDeleteOperations_NotGenerateDeleteItemCommand()
+        {
+            // Arrange
+            var sourceItems = new List<IDataItem>();
+            var sourceItem = new QuickContentDataItem(string.Empty, string.Empty, string.Empty, new SyncItem());
+            sourceItems.Add(sourceItem);
+
+            var targetItems = new List<IDataItem>();
+            var sourceDataIterator = new TestDataIterator(sourceItems);
+            var targetDataIterator = new TestDataIterator(targetItems);
+
+            var engineMock = new Mock<DataEngine>(null, null, new List<ICommandFilter>());
+
+            DiffGenerator.AllowedOperations = AllowedOperations.Create | AllowedOperations.Update;
+            
+            // Act
+            var commands = DiffGenerator.GetCommands(sourceDataIterator, targetDataIterator);
+
+            //Assert
+            Assert.AreEqual(0, commands.Count);
+            Assert.AreEqual(0, commands.Count(x => x is DeleteItemCommand));
+        }
 
         [Test]
         public void AddItemsTest()

--- a/Sitecore.Courier/AllowedOperations.cs
+++ b/Sitecore.Courier/AllowedOperations.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Sitecore.Courier
+{
+    [Flags]
+    public enum AllowedOperations
+    {
+        None = 0,
+        Create = 1,
+        Delete = 2,
+        Update= 4
+    }
+}

--- a/Sitecore.Courier/Sitecore.Courier.csproj
+++ b/Sitecore.Courier/Sitecore.Courier.csproj
@@ -130,6 +130,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AllowedOperations.cs" />
     <Compile Include="DacPac\DacPacBuilder.cs" />
     <Compile Include="DiffGenerator.cs" />
     <Compile Include="Iterators\EmptyIterator.cs" />


### PR DESCRIPTION
The default logic of Sitecore-Courier is to remove the item if it doesn't exist in the target source and it's working fine for most cases. The problem starts when some items were moved from one project to another. Therefore we have one package that tries to add the item and another package that removes that item.

My idea was to provide flags for all operations (Add, Remove, Update) and an input parameter that allows disabling one or many of those operations. Therefore we can use it to generate packages without removing operations.